### PR TITLE
Support STM with LL library, support ASCII chars directly, added much more glyphs 

### DIFF
--- a/TM1638.c
+++ b/TM1638.c
@@ -64,7 +64,7 @@
 /**
  * @brief  Convert HEX number to Seven-Segment code
  */
-const uint8_t HexTo7Seg[16+24] =
+const uint8_t HexTo7Seg[40] =
 {
   0x3F, // 0
   0x06, // 1
@@ -106,7 +106,6 @@ const uint8_t HexTo7Seg[16+24] =
   0x08, // _
   0x40, // -
   0x01  // high bar
-
 };
 
 
@@ -548,6 +547,25 @@ TM1638_SetMultipleDigit_HEX(TM1638_Handler_t *Handler, const uint8_t *DigitData,
                                  (const uint8_t *)DigitDataHEX, StartAddr, Count);
 }
 
+/**
+ * @brief  Set data to multiple digits in char format
+ * @param  Handler: Pointer to handler
+ * @param  DigitData: Array to Digits data. 
+ *                    Supported chars 0,1,2,3,4,5,6,7,8,9
+ *                                    A,b,C,d,E,F,g,G,h,H,i,I,j,l,L,n,N,o,O,P,q,r,S,t,u,U,y
+ *                                    _,-,high bar (use ~ to set)
+ * 
+ * @param  StartAddr: First digit position
+ *         - 0: Seg1
+ *         - 1: Seg2
+ *         - .
+ *         - .
+ *         - .
+ * 
+ * @param  Count: Number of segments to write data
+ * @retval TM1638_Result_t
+ *         - TM1638_OK: Operation was successful
+ */
 TM1638_Result_t
 TM1638_SetMultipleDigit_CHAR(TM1638_Handler_t *Handler, const uint8_t *DigitData,
                             uint8_t StartAddr, uint8_t Count)
@@ -700,8 +718,6 @@ TM1638_SetMultipleDigit_CHAR(TM1638_Handler_t *Handler, const uint8_t *DigitData
       case '~':
         DigitDataHEX[i] = HexTo7Seg[0x27] | DecimalPoint;
       break;
-
-
 
       default:
         DigitDataHEX[i] = 0;

--- a/TM1638.c
+++ b/TM1638.c
@@ -548,7 +548,7 @@ TM1638_SetMultipleDigit_HEX(TM1638_Handler_t *Handler, const uint8_t *DigitData,
  * @param  DigitData: Array to Digits data. 
  *                    Supported chars 0,1,2,3,4,5,6,7,8,9
  *                                    A,b,C,d,E,F,g,G,h,H,i,I,j,l,L,n,N,o,O,P,q,r,S,t,u,U,y
- *                                    _,-,high bar (use ~ to set)
+ *                                    _,-,Overscore (use ~ to set)
  * 
  * @param  StartAddr: First digit position
  *         - 0: Seg1

--- a/TM1638.c
+++ b/TM1638.c
@@ -531,11 +531,6 @@ TM1638_SetMultipleDigit_HEX(TM1638_Handler_t *Handler, const uint8_t *DigitData,
         DigitDataHEX[i] = HexTo7Seg[0x0F] | DecimalPoint;
         break;
 
-      case 0x40:
-        DigitDataHEX[i] = HexTo7Seg[0x10] | DecimalPoint;
-      break;
-
-
       default:
         DigitDataHEX[i] = 0;
         break;

--- a/TM1638.c
+++ b/TM1638.c
@@ -105,7 +105,7 @@ const uint8_t HexTo7Seg[40] =
   0x66, // y
   0x08, // _
   0x40, // -
-  0x01  // high bar
+  0x01  // Overscore
 };
 
 

--- a/TM1638.c
+++ b/TM1638.c
@@ -64,7 +64,7 @@
 /**
  * @brief  Convert HEX number to Seven-Segment code
  */
-const uint8_t HexTo7Seg[16] =
+const uint8_t HexTo7Seg[16+24] =
 {
   0x3F, // 0
   0x06, // 1
@@ -81,7 +81,32 @@ const uint8_t HexTo7Seg[16] =
   0x39, // C
   0x5E, // d
   0x79, // E
-  0x71  // F
+  0x71, // F
+  0x6F, // g
+  0x3D, // G
+  0x74, // h
+  0x76, // H
+  0x05, // i
+  0x06, // I
+  0x0D, // j
+  0x30, // l
+  0x38, // L
+  0x54, // n
+  0x37, // N
+  0x5C, // o
+  0x3F, // O
+  0x73, // P
+  0x67, // q
+  0x50, // r
+  0x6D, // S
+  0x78, // t
+  0x1C, // u
+  0x3E, // U
+  0x66, // y
+  0x08, // _
+  0x40, // -
+  0x01  // high bar
+
 };
 
 
@@ -507,6 +532,11 @@ TM1638_SetMultipleDigit_HEX(TM1638_Handler_t *Handler, const uint8_t *DigitData,
         DigitDataHEX[i] = HexTo7Seg[0x0F] | DecimalPoint;
         break;
 
+      case 0x40:
+        DigitDataHEX[i] = HexTo7Seg[0x10] | DecimalPoint;
+      break;
+
+
       default:
         DigitDataHEX[i] = 0;
         break;
@@ -518,6 +548,171 @@ TM1638_SetMultipleDigit_HEX(TM1638_Handler_t *Handler, const uint8_t *DigitData,
                                  (const uint8_t *)DigitDataHEX, StartAddr, Count);
 }
 
+TM1638_Result_t
+TM1638_SetMultipleDigit_CHAR(TM1638_Handler_t *Handler, const uint8_t *DigitData,
+                            uint8_t StartAddr, uint8_t Count)
+{
+  uint8_t DigitDataHEX[10];
+  uint8_t DecimalPoint = 0;
+
+  for (uint8_t i = 0; i < Count; i++)
+  {
+    DecimalPoint = DigitData[i] & 0x80;
+
+    // numbers 0 - 9
+    if ((DigitData[i] & 0x7F) >= (uint8_t)'0' && (DigitData[i] & 0x7F) <= (uint8_t)'9')
+    {
+      DigitDataHEX[i] = HexTo7Seg[(DigitData[i]-48) & 0x7F] | DecimalPoint;
+    }
+    else
+    {
+      switch (DigitData[i] & 0x7F)
+      {
+      case 'A':
+      case 'a':
+        DigitDataHEX[i] = HexTo7Seg[0x0A] | DecimalPoint;
+        break;
+
+      case 'B':
+      case 'b':
+        DigitDataHEX[i] = HexTo7Seg[0x0B] | DecimalPoint;
+        break;
+
+      case 'C':
+      case 'c':
+        DigitDataHEX[i] = HexTo7Seg[0x0C] | DecimalPoint;
+        break;
+
+      case 'D':
+      case 'd':
+        DigitDataHEX[i] = HexTo7Seg[0x0D] | DecimalPoint;
+        break;
+
+      case 'E':
+      case 'e':
+        DigitDataHEX[i] = HexTo7Seg[0x0E] | DecimalPoint;
+        break;
+
+      case 'F':
+      case 'f':
+        DigitDataHEX[i] = HexTo7Seg[0x0F] | DecimalPoint;
+        break;
+
+      case 'g':
+        DigitDataHEX[i] = HexTo7Seg[0x10] | DecimalPoint;
+      break;
+      
+      case 'G':
+        DigitDataHEX[i] = HexTo7Seg[0x11] | DecimalPoint;
+      break;
+
+      case 'h':
+        DigitDataHEX[i] = HexTo7Seg[0x12] | DecimalPoint;
+      break;
+      
+      case 'H':
+        DigitDataHEX[i] = HexTo7Seg[0x13] | DecimalPoint;
+      break;
+
+      case 'i':
+        DigitDataHEX[i] = HexTo7Seg[0x14] | DecimalPoint;
+      break;
+      
+      case 'I':
+        DigitDataHEX[i] = HexTo7Seg[0x15] | DecimalPoint;
+      break;
+
+      case 'j':
+      case 'J':
+        DigitDataHEX[i] = HexTo7Seg[0x16] | DecimalPoint;
+      break;
+
+      case 'l':
+        DigitDataHEX[i] = HexTo7Seg[0x17] | DecimalPoint;
+      break;
+
+      case 'L':
+        DigitDataHEX[i] = HexTo7Seg[0x18] | DecimalPoint;
+      break;
+
+      case 'n':
+        DigitDataHEX[i] = HexTo7Seg[0x19] | DecimalPoint;
+      break;
+      
+      case 'N':
+        DigitDataHEX[i] = HexTo7Seg[0x1A] | DecimalPoint;
+      break;
+
+      case 'o':
+        DigitDataHEX[i] = HexTo7Seg[0x1B] | DecimalPoint;
+      break;
+      
+      case 'O':
+        DigitDataHEX[i] = HexTo7Seg[0x1C] | DecimalPoint;
+      break;
+
+      case 'p':
+      case 'P':
+        DigitDataHEX[i] = HexTo7Seg[0x1D] | DecimalPoint;
+      break;
+
+      case 'q':
+      case 'Q':
+        DigitDataHEX[i] = HexTo7Seg[0x1E] | DecimalPoint;
+      break;
+
+      case 'r':
+      case 'R':
+        DigitDataHEX[i] = HexTo7Seg[0x1F] | DecimalPoint;
+      break;
+
+      case 's':
+      case 'S':
+        DigitDataHEX[i] = HexTo7Seg[0x20] | DecimalPoint;
+      break;
+
+      case 't':
+      case 'T':
+        DigitDataHEX[i] = HexTo7Seg[0x21] | DecimalPoint;
+      break;
+
+      case 'u':
+        DigitDataHEX[i] = HexTo7Seg[0x22] | DecimalPoint;
+      break;
+
+      case 'U':
+        DigitDataHEX[i] = HexTo7Seg[0x23] | DecimalPoint;
+      break;
+
+      case 'y':
+      case 'Y':
+        DigitDataHEX[i] = HexTo7Seg[0x24] | DecimalPoint;
+      break;
+
+      case '_':
+        DigitDataHEX[i] = HexTo7Seg[0x25] | DecimalPoint;
+      break;
+
+      case '-':
+        DigitDataHEX[i] = HexTo7Seg[0x26] | DecimalPoint;
+      break;
+
+      case '~':
+        DigitDataHEX[i] = HexTo7Seg[0x27] | DecimalPoint;
+      break;
+
+
+
+      default:
+        DigitDataHEX[i] = 0;
+        break;
+      }
+    }
+  }
+
+  return TM1638_SetMultipleDigit(Handler,
+                                 (const uint8_t *)DigitDataHEX, StartAddr, Count);
+}
 
 /** 
  ==================================================================================

--- a/TM1638.h
+++ b/TM1638.h
@@ -268,7 +268,7 @@ TM1638_SetMultipleDigit_HEX(TM1638_Handler_t *Handler, const uint8_t *DigitData,
  * @param  DigitData: Array to Digits data. 
  *                    Supported chars 0,1,2,3,4,5,6,7,8,9
  *                                    A,b,C,d,E,F,g,G,h,H,i,I,j,l,L,n,N,o,O,P,q,r,S,t,u,U,y
- *                                    _,-,high bar (use ~ to set)
+ *                                    _,-,Overscore (use ~ to set)
  * 
  * @param  StartAddr: First digit position
  *         - 0: Seg1

--- a/TM1638.h
+++ b/TM1638.h
@@ -262,7 +262,26 @@ TM1638_Result_t
 TM1638_SetMultipleDigit_HEX(TM1638_Handler_t *Handler, const uint8_t *DigitData,
                             uint8_t StartAddr, uint8_t Count);
 
-
+/**
+ * @brief  Set data to multiple digits in char format
+ * @param  Handler: Pointer to handler
+ * @param  DigitData: Array to Digits data. 
+ *                    (0, 1, ... , 15, a, A, b, B, ...)
+ * 
+ * @param  StartAddr: First digit position
+ *         - 0: Seg1
+ *         - 1: Seg2
+ *         - .
+ *         - .
+ *         - .
+ * 
+ * @param  Count: Number of segments to write data
+ * @retval TM1638_Result_t
+ *         - TM1638_OK: Operation was successful
+ */
+TM1638_Result_t
+TM1638_SetMultipleDigit_CHAR(TM1638_Handler_t *Handler, const uint8_t *DigitData,
+                            uint8_t StartAddr, uint8_t Count);
 
 /** 
  ==================================================================================

--- a/TM1638.h
+++ b/TM1638.h
@@ -266,7 +266,9 @@ TM1638_SetMultipleDigit_HEX(TM1638_Handler_t *Handler, const uint8_t *DigitData,
  * @brief  Set data to multiple digits in char format
  * @param  Handler: Pointer to handler
  * @param  DigitData: Array to Digits data. 
- *                    (0, 1, ... , 15, a, A, b, B, ...)
+ *                    Supported chars 0,1,2,3,4,5,6,7,8,9
+ *                                    A,b,C,d,E,F,g,G,h,H,i,I,j,l,L,n,N,o,O,P,q,r,S,t,u,U,y
+ *                                    _,-,high bar (use ~ to set)
  * 
  * @param  StartAddr: First digit position
  *         - 0: Seg1

--- a/TM1638_platform.c
+++ b/TM1638_platform.c
@@ -37,6 +37,8 @@
 #include <util/delay.h>
 #elif defined(TM1638_PLATFORM_STM32)
 #include "main.h"
+#elif defined(TM1638_PLATFORM_STM32_LL)
+#include "main.h"
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
 #include "freertos/FreeRTOS.h"
 #include "driver/gpio.h"
@@ -54,13 +56,26 @@
 #if defined(TM1638_PLATFORM_STM32)
 void TM1638_SetGPIO_OUT(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
 {
-  // GPIO_InitTypeDef GPIO_InitStruct = {0};
-  // GPIO_InitStruct.Pin = GPIO_Pin;
-  // GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-  // GPIO_InitStruct.Pull = GPIO_NOPULL;
-  // GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-  // HAL_GPIO_Init(GPIOx, &GPIO_InitStruct);
-
+  GPIO_InitTypeDef GPIO_InitStruct = {0};
+  GPIO_InitStruct.Pin = GPIO_Pin;
+  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  HAL_GPIO_Init(GPIOx, &GPIO_InitStruct);
+}
+									
+void TM1638_SetGPIO_IN_PU(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
+{
+  GPIO_InitTypeDef GPIO_InitStruct = {0};
+  GPIO_InitStruct.Pin = GPIO_Pin;
+  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+  GPIO_InitStruct.Pull = GPIO_PULLUP;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  HAL_GPIO_Init(GPIOx, &GPIO_InitStruct);
+}
+#elif defined(TM1638_PLATFORM_STM32_LL)
+void TM1638_SetGPIO_OUT(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
+{
   LL_GPIO_InitTypeDef GPIO_InitStruct = {0};
 
   GPIO_InitStruct.Pin = GPIO_Pin;
@@ -73,13 +88,6 @@ void TM1638_SetGPIO_OUT(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
 									
 void TM1638_SetGPIO_IN_PU(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
 {
-  // GPIO_InitTypeDef GPIO_InitStruct = {0};
-  // GPIO_InitStruct.Pin = GPIO_Pin;
-  // GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-  // GPIO_InitStruct.Pull = GPIO_PULLUP;
-  // GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-  // HAL_GPIO_Init(GPIOx, &GPIO_InitStruct);
-
   LL_GPIO_InitTypeDef GPIO_InitStruct = {0};
 
   GPIO_InitStruct.Pin = GPIO_Pin;
@@ -110,7 +118,7 @@ TM1638_PlatformInit(void)
   TM1638_CLK_DDR |= (1<<TM1638_CLK_NUM);
   TM1638_DIO_DDR |= (1<<TM1638_DIO_NUM);
   TM1638_STB_DDR |= (1<<TM1638_STB_NUM);
-#elif defined(TM1638_PLATFORM_STM32)
+#elif defined(TM1638_PLATFORM_STM32) || defined(TM1638_PLATFORM_STM32_LL)
   TM1638_SetGPIO_OUT(TM1638_CLK_GPIO, TM1638_CLK_PIN);
   TM1638_SetGPIO_OUT(TM1638_STB_GPIO, TM1638_STB_PIN);
   TM1638_SetGPIO_OUT(TM1638_DIO_GPIO, TM1638_DIO_PIN);
@@ -130,7 +138,7 @@ TM1638_PlatformDeInit(void)
   TM1638_DIO_PORT &= ~(1<<TM1638_DIO_NUM);
   TM1638_STB_DDR &= ~(1<<TM1638_STB_NUM);
   TM1638_STB_PORT &= ~(1<<TM1638_STB_NUM);
-#elif defined(TM1638_PLATFORM_STM32)
+#elif defined(TM1638_PLATFORM_STM32) || defined(TM1638_PLATFORM_STM32_LL)
 
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
   gpio_reset_pin(TM1638_CLK_GPIO);
@@ -144,7 +152,7 @@ TM1638_DioConfigOut(void)
 {
 #if defined(TM1638_PLATFORM_AVR)
   TM1638_DIO_DDR |= (1<<TM1638_DIO_NUM);
-#elif defined(TM1638_PLATFORM_STM32)
+#elif defined(TM1638_PLATFORM_STM32) || defined(TM1638_PLATFORM_STM32_LL)
   TM1638_SetGPIO_OUT(TM1638_DIO_GPIO, TM1638_DIO_PIN);
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
   TM1638_SetGPIO_OUT(TM1638_DIO_GPIO);
@@ -156,7 +164,7 @@ TM1638_DioConfigIn(void)
 {
 #if defined(TM1638_PLATFORM_AVR)
   TM1638_DIO_DDR &= ~(1<<TM1638_DIO_NUM);
-#elif defined(TM1638_PLATFORM_STM32)
+#elif defined(TM1638_PLATFORM_STM32) || defined(TM1638_PLATFORM_STM32_LL)
   TM1638_SetGPIO_IN_PU(TM1638_DIO_GPIO, TM1638_DIO_PIN);
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
   TM1638_SetGPIO_IN_PU(TM1638_DIO_GPIO);
@@ -172,7 +180,8 @@ TM1638_DioWrite(uint8_t Level)
   else
     TM1638_DIO_PORT &= ~(1<<TM1638_DIO_NUM);
 #elif defined(TM1638_PLATFORM_STM32)
-  //HAL_GPIO_WritePin(TM1638_DIO_GPIO, TM1638_DIO_PIN, Level);
+  HAL_GPIO_WritePin(TM1638_DIO_GPIO, TM1638_DIO_PIN, Level);
+#elif defined(TM1638_PLATFORM_STM32_LL)
   if( Level != 0u) {
     LL_GPIO_SetOutputPin(TM1638_DIO_GPIO, TM1638_DIO_PIN);
   }
@@ -191,7 +200,8 @@ TM1638_DioRead(void)
 #if defined(TM1638_PLATFORM_AVR)
   Result = (TM1638_DIO_PIN & (1 << TM1638_DIO_NUM)) ? 1 : 0;
 #elif defined(TM1638_PLATFORM_STM32)
-  //Result = HAL_GPIO_ReadPin(TM1638_DIO_GPIO, TM1638_DIO_PIN);
+  Result = HAL_GPIO_ReadPin(TM1638_DIO_GPIO, TM1638_DIO_PIN);
+#elif defined(TM1638_PLATFORM_STM32_LL)
   Result = (LL_GPIO_ReadInputPort(TM1638_DIO_GPIO) & TM1638_DIO_PIN) == TM1638_DIO_PIN;
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
   Result = gpio_get_level(TM1638_DIO_GPIO);
@@ -208,8 +218,9 @@ TM1638_ClkWrite(uint8_t Level)
   else
     TM1638_CLK_PORT &= ~(1<<TM1638_CLK_NUM);
 #elif defined(TM1638_PLATFORM_STM32)
-  //HAL_GPIO_WritePin(TM1638_CLK_GPIO, TM1638_CLK_PIN, Level);
-    if( Level != 0u) {
+  HAL_GPIO_WritePin(TM1638_CLK_GPIO, TM1638_CLK_PIN, Level);
+#elif defined(TM1638_PLATFORM_STM32_LL)
+  if( Level != 0u) {
     LL_GPIO_SetOutputPin(TM1638_CLK_GPIO, TM1638_CLK_PIN);
   }
   else {
@@ -229,7 +240,8 @@ TM1638_StbWrite(uint8_t Level)
   else
     TM1638_STB_PORT &= ~(1<<TM1638_STB_NUM);
 #elif defined(TM1638_PLATFORM_STM32)
-  //HAL_GPIO_WritePin(TM1638_STB_GPIO, TM1638_STB_PIN, Level);
+  HAL_GPIO_WritePin(TM1638_STB_GPIO, TM1638_STB_PIN, Level);
+#elif defined(TM1638_PLATFORM_STM32_LL)
   if( Level != 0u) {
     LL_GPIO_SetOutputPin(TM1638_STB_GPIO, TM1638_STB_PIN);
   }
@@ -247,7 +259,7 @@ TM1638_DelayUs(uint8_t Delay)
 #if defined(TM1638_PLATFORM_AVR)
   for (; Delay; --Delay)
     _delay_us(1);
-#elif defined(TM1638_PLATFORM_STM32)
+#elif defined(TM1638_PLATFORM_STM32) || defined(TM1638_PLATFORM_STM32_LL)
   for (uint32_t DelayCounter = 0; DelayCounter < 100 * Delay; DelayCounter++)
     DelayCounter = DelayCounter;
 #elif defined(TM1638_PLATFORM_ESP32_IDF)

--- a/TM1638_platform.c
+++ b/TM1638_platform.c
@@ -54,22 +54,39 @@
 #if defined(TM1638_PLATFORM_STM32)
 void TM1638_SetGPIO_OUT(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
 {
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
+  // GPIO_InitTypeDef GPIO_InitStruct = {0};
+  // GPIO_InitStruct.Pin = GPIO_Pin;
+  // GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+  // GPIO_InitStruct.Pull = GPIO_NOPULL;
+  // GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  // HAL_GPIO_Init(GPIOx, &GPIO_InitStruct);
+
+  LL_GPIO_InitTypeDef GPIO_InitStruct = {0};
+
   GPIO_InitStruct.Pin = GPIO_Pin;
-  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-  GPIO_InitStruct.Pull = GPIO_NOPULL;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-  HAL_GPIO_Init(GPIOx, &GPIO_InitStruct);
+  GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;
+  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+  GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+  GPIO_InitStruct.Pull = LL_GPIO_PULL_NO;
+  LL_GPIO_Init(GPIOx, &GPIO_InitStruct);
 }
 									
 void TM1638_SetGPIO_IN_PU(GPIO_TypeDef *GPIOx, uint32_t GPIO_Pin)
 {
-  GPIO_InitTypeDef GPIO_InitStruct = {0};
+  // GPIO_InitTypeDef GPIO_InitStruct = {0};
+  // GPIO_InitStruct.Pin = GPIO_Pin;
+  // GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
+  // GPIO_InitStruct.Pull = GPIO_PULLUP;
+  // GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  // HAL_GPIO_Init(GPIOx, &GPIO_InitStruct);
+
+  LL_GPIO_InitTypeDef GPIO_InitStruct = {0};
+
   GPIO_InitStruct.Pin = GPIO_Pin;
-  GPIO_InitStruct.Mode = GPIO_MODE_INPUT;
-  GPIO_InitStruct.Pull = GPIO_PULLUP;
-  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-  HAL_GPIO_Init(GPIOx, &GPIO_InitStruct);
+  GPIO_InitStruct.Mode = LL_GPIO_MODE_INPUT;
+  GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_LOW;
+  GPIO_InitStruct.Pull = LL_GPIO_PULL_UP;
+  LL_GPIO_Init(GPIOx, &GPIO_InitStruct);
 }
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
 void TM1638_SetGPIO_OUT(gpio_num_t GPIO_Pad)
@@ -155,7 +172,13 @@ TM1638_DioWrite(uint8_t Level)
   else
     TM1638_DIO_PORT &= ~(1<<TM1638_DIO_NUM);
 #elif defined(TM1638_PLATFORM_STM32)
-  HAL_GPIO_WritePin(TM1638_DIO_GPIO, TM1638_DIO_PIN, Level);
+  //HAL_GPIO_WritePin(TM1638_DIO_GPIO, TM1638_DIO_PIN, Level);
+  if( Level != 0u) {
+    LL_GPIO_SetOutputPin(TM1638_DIO_GPIO, TM1638_DIO_PIN);
+  }
+  else {
+    LL_GPIO_ResetOutputPin(TM1638_DIO_GPIO, TM1638_DIO_PIN);
+  }
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
   gpio_set_level(TM1638_DIO_GPIO, Level);
 #endif
@@ -168,7 +191,8 @@ TM1638_DioRead(void)
 #if defined(TM1638_PLATFORM_AVR)
   Result = (TM1638_DIO_PIN & (1 << TM1638_DIO_NUM)) ? 1 : 0;
 #elif defined(TM1638_PLATFORM_STM32)
-  Result = HAL_GPIO_ReadPin(TM1638_DIO_GPIO, TM1638_DIO_PIN);
+  //Result = HAL_GPIO_ReadPin(TM1638_DIO_GPIO, TM1638_DIO_PIN);
+  Result = (LL_GPIO_ReadInputPort(TM1638_DIO_GPIO) & TM1638_DIO_PIN) == TM1638_DIO_PIN;
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
   Result = gpio_get_level(TM1638_DIO_GPIO);
 #endif
@@ -184,7 +208,13 @@ TM1638_ClkWrite(uint8_t Level)
   else
     TM1638_CLK_PORT &= ~(1<<TM1638_CLK_NUM);
 #elif defined(TM1638_PLATFORM_STM32)
-  HAL_GPIO_WritePin(TM1638_CLK_GPIO, TM1638_CLK_PIN, Level);
+  //HAL_GPIO_WritePin(TM1638_CLK_GPIO, TM1638_CLK_PIN, Level);
+    if( Level != 0u) {
+    LL_GPIO_SetOutputPin(TM1638_CLK_GPIO, TM1638_CLK_PIN);
+  }
+  else {
+    LL_GPIO_ResetOutputPin(TM1638_CLK_GPIO, TM1638_CLK_PIN);
+  }
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
   gpio_set_level(TM1638_CLK_GPIO, Level);
 #endif
@@ -199,7 +229,13 @@ TM1638_StbWrite(uint8_t Level)
   else
     TM1638_STB_PORT &= ~(1<<TM1638_STB_NUM);
 #elif defined(TM1638_PLATFORM_STM32)
-  HAL_GPIO_WritePin(TM1638_STB_GPIO, TM1638_STB_PIN, Level);
+  //HAL_GPIO_WritePin(TM1638_STB_GPIO, TM1638_STB_PIN, Level);
+  if( Level != 0u) {
+    LL_GPIO_SetOutputPin(TM1638_STB_GPIO, TM1638_STB_PIN);
+  }
+  else {
+    LL_GPIO_ResetOutputPin(TM1638_STB_GPIO, TM1638_STB_PIN);
+  }
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
   gpio_set_level(TM1638_STB_GPIO, Level);
 #endif

--- a/TM1638_platform.h
+++ b/TM1638_platform.h
@@ -48,7 +48,8 @@ extern "C" {
  * @note   Uncomment the line below according to the target platform
  */ 
 // #define TM1638_PLATFORM_AVR          // ATmega32
-#define TM1638_PLATFORM_STM32        // HAL Functions
+// #define TM1638_PLATFORM_STM32        // HAL Functions
+#define TM1638_PLATFORM_STM32_LL        // LL Functions
 // #define TM1638_PLATFORM_ESP32_IDF    // ESP-IDF
 
 
@@ -73,11 +74,23 @@ extern "C" {
  * @brief  Specify IO Pins of STM32 connected to TM1638
  */
 #define TM1638_CLK_GPIO     GPIOA
+#define TM1638_CLK_PIN      GPIO_PIN_0
+#define TM1638_DIO_GPIO     GPIOA
+#define TM1638_DIO_PIN      GPIO_PIN_1
+#define TM1638_STB_GPIO     GPIOA
+#define TM1638_STB_PIN      GPIO_PIN_3
+
+#elif defined(TM1638_PLATFORM_STM32_LL)
+/**
+ * @brief  Specify IO Pins of STM32 connected to TM1638 using LL
+ */
+#define TM1638_CLK_GPIO     GPIOA
 #define TM1638_CLK_PIN      LL_GPIO_PIN_1
 #define TM1638_DIO_GPIO     GPIOA
 #define TM1638_DIO_PIN      LL_GPIO_PIN_4
 #define TM1638_STB_GPIO     GPIOA
 #define TM1638_STB_PIN      LL_GPIO_PIN_0
+
 
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
 /**

--- a/TM1638_platform.h
+++ b/TM1638_platform.h
@@ -78,7 +78,7 @@ extern "C" {
 #define TM1638_DIO_GPIO     GPIOA
 #define TM1638_DIO_PIN      GPIO_PIN_1
 #define TM1638_STB_GPIO     GPIOA
-#define TM1638_STB_PIN      GPIO_PIN_3
+#define TM1638_STB_PIN      GPIO_PIN_2
 
 #elif defined(TM1638_PLATFORM_STM32_LL)
 /**
@@ -87,9 +87,9 @@ extern "C" {
 #define TM1638_CLK_GPIO     GPIOA
 #define TM1638_CLK_PIN      LL_GPIO_PIN_1
 #define TM1638_DIO_GPIO     GPIOA
-#define TM1638_DIO_PIN      LL_GPIO_PIN_4
+#define TM1638_DIO_PIN      LL_GPIO_PIN_2
 #define TM1638_STB_GPIO     GPIOA
-#define TM1638_STB_PIN      LL_GPIO_PIN_0
+#define TM1638_STB_PIN      LL_GPIO_PIN_3
 
 
 #elif defined(TM1638_PLATFORM_ESP32_IDF)

--- a/TM1638_platform.h
+++ b/TM1638_platform.h
@@ -48,7 +48,7 @@ extern "C" {
  * @note   Uncomment the line below according to the target platform
  */ 
 // #define TM1638_PLATFORM_AVR          // ATmega32
-// #define TM1638_PLATFORM_STM32        // HAL Functions
+#define TM1638_PLATFORM_STM32        // HAL Functions
 // #define TM1638_PLATFORM_ESP32_IDF    // ESP-IDF
 
 
@@ -73,11 +73,11 @@ extern "C" {
  * @brief  Specify IO Pins of STM32 connected to TM1638
  */
 #define TM1638_CLK_GPIO     GPIOA
-#define TM1638_CLK_PIN      GPIO_PIN_0
+#define TM1638_CLK_PIN      LL_GPIO_PIN_1
 #define TM1638_DIO_GPIO     GPIOA
-#define TM1638_DIO_PIN      GPIO_PIN_1
+#define TM1638_DIO_PIN      LL_GPIO_PIN_4
 #define TM1638_STB_GPIO     GPIOA
-#define TM1638_STB_PIN      GPIO_PIN_2
+#define TM1638_STB_PIN      LL_GPIO_PIN_0
 
 #elif defined(TM1638_PLATFORM_ESP32_IDF)
 /**


### PR DESCRIPTION
Hello Coders,

I added following features:

- support of LL library for STM32 target
- support of directly using ASCII chars - enables to use sprintf output directly
- support more glyphs : latin alphabet as described here: https://en.wikipedia.org/wiki/Seven-segment_display

`sprintf(cData, "HELLO_-~");`
![Hello](https://github.com/MahdaSystem/TM1638/assets/125079210/dd586ea8-ed00-4e20-a14c-81ebc7715d62)

`sprintf(cData, "_-~coder");`
![coder](https://github.com/MahdaSystem/TM1638/assets/125079210/35565ea6-98f7-481d-b25d-276b8fb67169)

`sprintf(cData, "_-~go~-_");`
![go](https://github.com/MahdaSystem/TM1638/assets/125079210/2e9d44bc-c6fa-43fd-9a95-62829e9c4393)

`sprintf(cData, "~-_on_-~");`
![on](https://github.com/MahdaSystem/TM1638/assets/125079210/1fd99fbd-c621-4c87-85b1-442b040eab41)

`sprintf(cData, "start at");`
![start_at](https://github.com/MahdaSystem/TM1638/assets/125079210/a5d3d539-8b6f-48ac-957d-3fa534b19b4f)

`sprintf(cData, "%2d-%2d-%2d", Now.hour, Now.minutes, Now.seconds);`
![clock](https://github.com/MahdaSystem/TM1638/assets/125079210/20e787da-e543-4b8c-96fe-a6942d872c9f)

Tested with different controllers.

With best regards from germany,

Vinzenz Petr
